### PR TITLE
Fix rollup and bump amqp sdk to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -989,11 +989,12 @@
 			}
 		},
 		"@cesarbr/knot-cloud-sdk-js-amqp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-amqp/-/knot-cloud-sdk-js-amqp-1.0.0.tgz",
-			"integrity": "sha512-OZ4uNKr1bQWToO3pDmqXpPGyP8MAmoHUuxc3IPpzRMKnasyNqg0taQ8ebwQGCx6Bq5iyVqI46U/z0f6Zyzpacw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-amqp/-/knot-cloud-sdk-js-amqp-1.0.1.tgz",
+			"integrity": "sha512-undRzIz5IpXpLUC25jYbfbOGFdkpnnBnV0JtVLj6LXLl4BR0fFxk6pl10H1fwSRDJ0TfT5UDjqBsuJQ5o37u4Q==",
 			"requires": {
-				"amqplib": "^0.5.5"
+				"amqplib": "^0.5.5",
+				"uniqid": "^5.2.0"
 			}
 		},
 		"@cesarbr/knot-cloud-sdk-js-authenticator": {
@@ -6244,6 +6245,11 @@
 				"is-extendable": "^0.1.1",
 				"set-value": "^2.0.1"
 			}
+		},
+		"uniqid": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/uniqid/-/uniqid-5.2.0.tgz",
+			"integrity": "sha512-LH8zsvwJ/GL6YtNfSOmMCrI9piraAUjBfw2MCvleNE6a4pVKJwXjG2+HWhkVeFcSg+nmaPKbMrMOoxwQluZ1Mg=="
 		},
 		"unset-value": {
 			"version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -988,12 +988,29 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@cesarbr/knot-cloud-sdk-js-amqp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-amqp/-/knot-cloud-sdk-js-amqp-1.0.0.tgz",
+			"integrity": "sha512-OZ4uNKr1bQWToO3pDmqXpPGyP8MAmoHUuxc3IPpzRMKnasyNqg0taQ8ebwQGCx6Bq5iyVqI46U/z0f6Zyzpacw==",
+			"requires": {
+				"amqplib": "^0.5.5"
+			}
+		},
 		"@cesarbr/knot-cloud-sdk-js-authenticator": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-authenticator/-/knot-cloud-sdk-js-authenticator-2.0.0.tgz",
 			"integrity": "sha512-1pEB2BPlWwGfD/FGTP6u0out3z98CvB7PA6NyXjhYGfAd08vrkuTHt5HzbdBzNHiz7Je8xSVKjrJi+IoUCl/fg==",
 			"requires": {
 				"axios": "^0.19.0"
+			}
+		},
+		"@cesarbr/knot-cloud-sdk-js-storage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@cesarbr/knot-cloud-sdk-js-storage/-/knot-cloud-sdk-js-storage-1.0.2.tgz",
+			"integrity": "sha512-35kA7LTgSodH1VCQ7aIltmuSN5SYz0ADQEXnmXuwbmKB5rukNUejCDziGz342mdvczVlRJ8BGF8fckyiTCxWYQ==",
+			"requires": {
+				"axios": "^0.19.0",
+				"url": "^0.11.0"
 			}
 		},
 		"@rollup/plugin-json": {
@@ -1130,6 +1147,42 @@
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			}
+		},
+		"amqplib": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.5.tgz",
+			"integrity": "sha512-sWx1hbfHbyKMw6bXOK2k6+lHL8TESWxjAx5hG8fBtT7wcxoXNIsFxZMnFyBjxt3yL14vn7WqBDe5U6BGOadtLg==",
+			"requires": {
+				"bitsyntax": "~0.1.0",
+				"bluebird": "^3.5.2",
+				"buffer-more-ints": "~1.0.0",
+				"readable-stream": "1.x >=1.1.9",
+				"safe-buffer": "~5.1.2",
+				"url-parse": "~1.4.3"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
 			}
 		},
 		"ansi-escapes": {
@@ -1396,6 +1449,26 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"bitsyntax": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.1.0.tgz",
+			"integrity": "sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==",
+			"requires": {
+				"buffer-more-ints": "~1.0.0",
+				"debug": "~2.6.9",
+				"safe-buffer": "~5.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
 		"bl": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
@@ -1430,6 +1503,11 @@
 					"dev": true
 				}
 			}
+		},
+		"bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -1580,6 +1658,11 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
+		},
+		"buffer-more-ints": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+			"integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg=="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -1852,8 +1935,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"create-ecdh": {
 			"version": "4.0.3",
@@ -3613,8 +3695,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"inquirer": {
 			"version": "7.1.0",
@@ -5008,6 +5089,16 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
+		"querystringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5225,6 +5316,11 @@
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true,
 			"optional": true
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"reselect": {
 			"version": "3.0.1",
@@ -5478,8 +5574,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -6216,6 +6311,31 @@
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"dev": true,
 			"optional": true
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
+		"url-parse": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+			"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+			"requires": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
 		},
 		"use": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"lint"
 	],
 	"dependencies": {
-		"@cesarbr/knot-cloud-sdk-js-amqp": "^1.0.0",
+		"@cesarbr/knot-cloud-sdk-js-amqp": "^1.0.1",
 		"@cesarbr/knot-cloud-sdk-js-authenticator": "^2.0.0",
 		"@cesarbr/knot-cloud-sdk-js-storage": "^1.0.2",
 		"@rollup/plugin-json": "^4.0.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
 import autoExternal from 'rollup-plugin-auto-external';
+import json from '@rollup/plugin-json';
 
 import pkg from './package.json';
 
@@ -25,6 +26,7 @@ export default [
         preferBuiltins: true,
       }),
       commonjs(),
+      json(),
       babel({
         exclude: [
           'node_modules/**',


### PR DESCRIPTION
This patch adds a missing plugin to the rollup configuration in order to avoid the build to break. In addition, it also bumps the amqp sdk version to v1.0.1.